### PR TITLE
Fixing the Linux node installation instructions because the previous …

### DIFF
--- a/class-01-jquery-and-the-dom/day1-computerSetup.md
+++ b/class-01-jquery-and-the-dom/day1-computerSetup.md
@@ -3,28 +3,34 @@
 ## Install Atom
 
   If you haven't already, install [Atom](https://atom.io). Atom is similar to Sublime Text in that it is also a text editor. Atom however, is free, open-source, and cross-platform. Please use Atom during Code 301.
-  
+
   Atom's [documentation](https://atom.io/docs/latest) is top-notch. Go check it out. Make sure you're looking at the docs for the latest version.
 
 ## Install Node
   *Note* If you get an error while installing these packages such as "try again as root/administrator", you may need to use the `sudo` command to get administrator access. For example `sudo apt-get install nodejs`.
 
   **Linux instructions**
-  
-  To install Node, open your Terminal, and enter:
-  
-  `apt-get install nodejs`
+
+  To install Node, open your Terminal, and copy and paste the following line, then hit Enter:
+
+  `curl -sL https://deb.nodesource.com/setup_5.x | sudo -E bash -`
+
+  It will churn away for a while, and then once it's done you can run the following command:
+
+  `sudo apt-get install nodejs`
+
+  If that doesn't work, try [these instructions to build from source](https://gist.github.com/toastynerd/d3e563522977f6750c32).
 
   **Mac instructions**
-  
+
   If you took Code 201, you should already have Homebrew installed. If you have not, follow the guide on [this page](https://github.com/codefellows/code-201-prework/blob/master/prework/mac/2_homebrew.md#install-homebrew).
-  
+
   To install Node, open your Terminal, and enter:
-   
+
   `brew install node`
 
   **Windows instructions**
-  
+
   To install Node, go [here](https://nodejs.org/en/download/), and then download and run the Windows Installer. Make sure you do not deselect any of the Node components such as NPM during the installation.
 
 ### Verify the Node installation
@@ -62,9 +68,9 @@ You should get two success messages while it installs the linter and linter-esli
 Enter the following into your Terminal:
 
 `apm ls`
- 
+
  ![](http://i.imgur.com/Jlv6LeP.png)
- 
+
  You should get a long list and at the end you should get a list of packages you installed for Atom. Linter and linter-eslint should be on that list.
 
 Congrats! You're all done.


### PR DESCRIPTION
…ones didn't work on Ubuntu

Instructions taken from Emily's update of them in the Seattle 301 d2 class, with an additional link for instructions for building from source. 

We are probably going to be able to update these next month, when Ubuntu releases their next LTS release and hopefully fixes the problem. (we should probably keep the source instructions around as a backup though) The problem seems to be that the version of node in the Ubuntu repos is stuck at the same version as it was when the last LTS release went out. Thus, the new LTS should fix it. Maybe. I hope. 